### PR TITLE
Add cell style updates and updateStyles tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ AI-powered spreadsheet using **Tambo** (https://tambo.co) + FortuneSheet. See ht
 - `TabsState` - Sheet ids/names/active tab (interactable)
 
 **Tools:** `src/tools/spreadsheet-tools.ts`
-- updateCell, updateRange, readCell, readRange
+- updateCell, updateRange, **updateStyles**, readCell, readRange
 - addRow, removeRow, addColumn, removeColumn
 - clearRange, sortByColumn
 


### PR DESCRIPTION
## Summary
- Added comprehensive updateStyles tool for cell formatting
- Added Conductor workspace configuration

## Changes
- Enhanced spreadsheet-tools.ts with new updateStyles functionality (377 new lines)
- Added conductor.json configuration
- Added conductor-setup.sh script
- Updated AGENTS.md documentation

## Test plan
- [x] Tool successfully formats cells with various styles
- [x] Conductor workspace properly configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a new tool to apply cell formatting to ranges and updates docs to reference it.
> 
> - **Tools (`src/tools/spreadsheet-tools.ts`)**:
>   - **New `updateSpreadsheetCellStyles` tool**: Apply formatting (bold/italic/underline/strikethrough, font family/size, font/background color, alignment, wrap, rotation) to one or more ranges.
>     - Adds `styleOptionsSchema` and `styleTargetSchema` with validation (hex color normalization, required targets, range bounds checks).
>     - Maps style options to FortuneSheet attributes and applies via `setCellFormatByRange`; returns applied ranges and summaries.
>     - Exported via `updateCellStylesTool` and included in `spreadsheetTools`.
> - **Docs (`AGENTS.md`)**:
>   - Tools list updated to include `updateStyles`.
>   - Commit guidance line formatting adjusted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d75ca55e4634c37ff221883433bb64c3bfcc0f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->