### PR TITLE
Add Tambo branding to the application

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ Learn more about Tambo:
 
 Built with [Tambo AI](https://tambo.co) - A framework for building AI-powered UIs. Tambo is open source: [tambo-ai/tambo](https://github.com/tambo-ai/tambo).
 
+![Tambo Template Demo](https://raw.githubusercontent.com/tambo-ai/tambo/main/assets/template.gif)
+
 ## Contributing
 
 Contributions welcome! See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines.

--- a/src/components/tambo/message-thread-full.tsx
+++ b/src/components/tambo/message-thread-full.tsx
@@ -38,6 +38,7 @@ import type { Suggestion } from "@tambo-ai/react";
 import type { VariantProps } from "class-variance-authority";
 import * as React from "react";
 import { cn } from "@/lib/utils";
+import Image from "next/image";
 
 /**
  * GitHub button component for the sidebar
@@ -80,6 +81,52 @@ const GitHubButton = React.forwardRef<
 GitHubButton.displayName = "GitHubButton";
 
 /**
+ * Tambo button component for the sidebar
+ */
+const TamboButton = React.forwardRef<
+  HTMLAnchorElement,
+  React.AnchorHTMLAttributes<HTMLAnchorElement>
+>(({ ...props }, ref) => {
+  const { isCollapsed } = useThreadHistoryContext();
+
+  const tamboUrl = "https://tambo.co";
+
+  return (
+    <a
+      ref={ref}
+      href={tamboUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn(
+        "flex items-center rounded-md mb-4 hover:bg-backdrop transition-colors cursor-pointer relative",
+        isCollapsed ? "p-1 justify-center" : "p-2 gap-2",
+      )}
+      title="Built with Tambo"
+      {...props}
+    >
+      <Image
+        src="/Octo-Icon.svg"
+        alt="Tambo"
+        width={16}
+        height={16}
+        className="text-muted-foreground hover:text-foreground transition-colors"
+      />
+      <span
+        className={cn(
+          "text-sm font-medium whitespace-nowrap absolute left-8 pb-[2px]",
+          isCollapsed
+            ? "opacity-0 max-w-0 overflow-hidden pointer-events-none"
+            : "opacity-100 transition-all duration-300 delay-100",
+        )}
+      >
+        Built with Tambo AI
+      </span>
+    </a>
+  );
+});
+TamboButton.displayName = "TamboButton";
+
+/**
  * Props for the MessageThreadFull component
  */
 export interface MessageThreadFullProps
@@ -109,6 +156,7 @@ export const MessageThreadFull = React.forwardRef<
     <ThreadHistory contextKey={contextKey} position={historyPosition}>
       <ThreadHistoryHeader />
       <GitHubButton />
+      <TamboButton />
       <ThreadHistoryNewButton />
       <ThreadHistorySearch />
       <ThreadHistoryList />
@@ -171,6 +219,19 @@ export const MessageThreadFull = React.forwardRef<
         <MessageSuggestions initialSuggestions={defaultSuggestions}>
           <MessageSuggestionsList />
         </MessageSuggestions>
+
+        {/* Footer */}
+        <div className="px-4 pb-2 text-center text-xs text-muted-foreground">
+          Built with{" "}
+          <a
+            href="https://tambo.co"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-foreground transition-colors underline underline-offset-2"
+          >
+            tambo-ai
+          </a>
+        </div>
       </ThreadContainer>
 
       {/* Thread History Sidebar - rendered last if history is on the right */}


### PR DESCRIPTION
## Summary
- Add Octo icon button in sidebar linking to tambo.co with "Built with Tambo AI" label
- Add footer with "Built with tambo-ai" link in the chat thread below suggestions
- Add animated GIF to README showcasing Tambo template demo capabilities

## Changes
- `src/components/tambo/message-thread-full.tsx`: New TamboButton component and footer
- `README.md`: Added template demo GIF

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Tambo-branded sidebar button and footer link, and updates README with a demo GIF.
> 
> - **UI (chat thread)**:
>   - **Sidebar branding**: Adds `TamboButton` (links to `https://tambo.co`) and integrates it into `ThreadHistory` in `src/components/tambo/message-thread-full.tsx`.
>   - **Footer**: Adds "Built with tambo-ai" link below message suggestions.
>   - Uses Next.js `Image` for the Tambo icon.
> - **Docs**:
>   - Adds demo GIF to `README.md` showcasing the Tambo template.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf7f793d288a2f056f35508c20e4278797acdf87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->