### PR TITLE
Restore GitHub and Tambo sidebar buttons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,3 +52,10 @@ AI-powered spreadsheet using **Tambo** (https://tambo.co) + FortuneSheet. See ht
 **Commits:**
 - Imperative mood (`Add utils`, `Fix context`)
 - Mention affected Tambo tools/components explicitly
+
+**Dependency Upgrades:**
+- When upgrading Tambo packages or UI components, preserve custom edits
+- Key customizations to preserve:
+  - `src/components/tambo/message-thread-full.tsx` - GitHub and Tambo buttons in sidebar
+  - `src/components/tambo/thread-history.tsx` - Exported `useThreadHistoryContext` hook
+- Always review diffs before accepting upstream changes

--- a/src/components/tambo/message-thread-full.tsx
+++ b/src/components/tambo/message-thread-full.tsx
@@ -31,11 +31,101 @@ import {
   ThreadHistoryList,
   ThreadHistoryNewButton,
   ThreadHistorySearch,
+  useThreadHistoryContext,
 } from "@/components/tambo/thread-history";
 import { useMergeRefs } from "@/lib/thread-hooks";
 import type { Suggestion } from "@tambo-ai/react";
 import type { VariantProps } from "class-variance-authority";
 import * as React from "react";
+import { cn } from "@/lib/utils";
+import { GithubIcon } from "lucide-react";
+import Image from "next/image";
+
+/**
+ * GitHub button component for the sidebar
+ */
+const GitHubButton = React.forwardRef<
+  HTMLAnchorElement,
+  React.AnchorHTMLAttributes<HTMLAnchorElement>
+>(({ ...props }, ref) => {
+  const { isCollapsed } = useThreadHistoryContext();
+
+  const githubRepoUrl = "https://github.com/michaelmagan/cheatsheet";
+
+  return (
+    <a
+      ref={ref}
+      href={githubRepoUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn(
+        "flex items-center rounded-md mb-4 hover:bg-backdrop transition-colors cursor-pointer relative",
+        isCollapsed ? "p-1 justify-center" : "p-2 gap-2",
+      )}
+      title="View on GitHub"
+      {...props}
+    >
+      <GithubIcon className="h-4 w-4 text-muted-foreground hover:text-foreground transition-colors" />
+      <span
+        className={cn(
+          "text-sm font-medium whitespace-nowrap absolute left-8 pb-[2px]",
+          isCollapsed
+            ? "opacity-0 max-w-0 overflow-hidden pointer-events-none"
+            : "opacity-100 transition-all duration-300 delay-100",
+        )}
+      >
+        GitHub Repo
+      </span>
+    </a>
+  );
+});
+GitHubButton.displayName = "GitHubButton";
+
+/**
+ * Tambo button component for the sidebar
+ */
+const TamboButton = React.forwardRef<
+  HTMLAnchorElement,
+  React.AnchorHTMLAttributes<HTMLAnchorElement>
+>(({ ...props }, ref) => {
+  const { isCollapsed } = useThreadHistoryContext();
+
+  const tamboUrl = "https://tambo.co";
+
+  return (
+    <a
+      ref={ref}
+      href={tamboUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn(
+        "flex items-center rounded-md mb-4 hover:bg-backdrop transition-colors cursor-pointer relative",
+        isCollapsed ? "p-1 justify-center" : "p-2 gap-2",
+      )}
+      title="Built with Tambo"
+      {...props}
+    >
+      <Image
+        src="/Octo-Icon.svg"
+        alt="Tambo"
+        width={16}
+        height={16}
+        className="text-muted-foreground hover:text-foreground transition-colors"
+      />
+      <span
+        className={cn(
+          "text-sm font-medium whitespace-nowrap absolute left-8 pb-[2px]",
+          isCollapsed
+            ? "opacity-0 max-w-0 overflow-hidden pointer-events-none"
+            : "opacity-100 transition-all duration-300 delay-100",
+        )}
+      >
+        Built with Tambo AI
+      </span>
+    </a>
+  );
+});
+TamboButton.displayName = "TamboButton";
 
 /**
  * Props for the MessageThreadFull component
@@ -66,6 +156,8 @@ export const MessageThreadFull = React.forwardRef<
   const threadHistorySidebar = (
     <ThreadHistory contextKey={contextKey} position={historyPosition}>
       <ThreadHistoryHeader />
+      <GitHubButton />
+      <TamboButton />
       <ThreadHistoryNewButton />
       <ThreadHistorySearch />
       <ThreadHistoryList />

--- a/src/components/tambo/thread-history.tsx
+++ b/src/components/tambo/thread-history.tsx
@@ -658,4 +658,5 @@ export {
   ThreadHistoryNewButton,
   ThreadHistorySearch,
   ThreadOptionsDropdown,
+  useThreadHistoryContext,
 };


### PR DESCRIPTION
## Summary
- Restore GitHubButton and TamboButton components to the message-thread-full sidebar
- Export useThreadHistoryContext hook from thread-history module for button usage
- Add upgrade reminder to AGENTS.md documenting custom edits to preserve

## Test plan
- Verify buttons appear in sidebar with correct links (GitHub repo, tambo.co)
- Confirm buttons collapse/expand with sidebar state
- Check TypeScript compilation passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)