### PR TITLE
Fix Next.js workspace root warning

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  outputFileTracingRoot: process.cwd(),
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
Added `outputFileTracingRoot: process.cwd()` to Next.js config to prevent incorrect workspace root inference when multiple lockfiles exist in parent directories.

## Changes
- Set `outputFileTracingRoot` in `next.config.ts` to explicitly specify the current working directory as the project root
- Resolves the build warning about detected multiple lockfiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)