### PR TITLE
docs: Auto-translate README and Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
+
+<div align="right">
+  <details>
+    <summary >🌐 Language</summary>
+    <div>
+      <div align="center">
+        <a href="https://openaitx.github.io/view.html?user=michaelmagan&project=cheatsheet&lang=en">English</a>
+        | <a href="https://openaitx.github.io/view.html?user=michaelmagan&project=cheatsheet&lang=zh-CN">简体中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=michaelmagan&project=cheatsheet&lang=zh-TW">繁體中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=michaelmagan&project=cheatsheet&lang=ja">日本語</a>
+        | <a href="https://openaitx.github.io/view.html?user=michaelmagan&project=cheatsheet&lang=ko">한국어</a>
+        | <a href="https://openaitx.github.io/view.html?user=michaelmagan&project=cheatsheet&lang=hi">हिन्दी</a>
+        | <a href="https://openaitx.github.io/view.html?user=michaelmagan&project=cheatsheet&lang=th">ไทย</a>
+        | <a href="https://openaitx.github.io/view.html?user=michaelmagan&project=cheatsheet&lang=fr">Français</a>
+        | <a href="https://openaitx.github.io/view.html?user=michaelmagan&project=cheatsheet&lang=de">Deutsch</a>
+        | <a href="https://openaitx.github.io/view.html?user=michaelmagan&project=cheatsheet&lang=es">Español</a>
+        | <a href="https://openaitx.github.io/view.html?user=michaelmagan&project=cheatsheet&lang=it">Italiano</a>
+        | <a href="https://openaitx.github.io/view.html?user=michaelmagan&project=cheatsheet&lang=ru">Русский</a>
+        | <a href="https://openaitx.github.io/view.html?user=michaelmagan&project=cheatsheet&lang=pt">Português</a>
+        | <a href="https://openaitx.github.io/view.html?user=michaelmagan&project=cheatsheet&lang=nl">Nederlands</a>
+        | <a href="https://openaitx.github.io/view.html?user=michaelmagan&project=cheatsheet&lang=pl">Polski</a>
+        | <a href="https://openaitx.github.io/view.html?user=michaelmagan&project=cheatsheet&lang=ar">العربية</a>
+        | <a href="https://openaitx.github.io/view.html?user=michaelmagan&project=cheatsheet&lang=fa">فارسی</a>
+        | <a href="https://openaitx.github.io/view.html?user=michaelmagan&project=cheatsheet&lang=tr">Türkçe</a>
+        | <a href="https://openaitx.github.io/view.html?user=michaelmagan&project=cheatsheet&lang=vi">Tiếng Việt</a>
+        | <a href="https://openaitx.github.io/view.html?user=michaelmagan&project=cheatsheet&lang=id">Bahasa Indonesia</a>
+        | <a href="https://openaitx.github.io/view.html?user=michaelmagan&project=cheatsheet&lang=as">অসমীয়া</
+      </div>
+    </div>
+  </details>
+</div>
+
 # Cheat Sheet
 
 [![GitHub](https://img.shields.io/badge/github-michaelmagan/cheatsheet-blue?logo=github)](https://github.com/michaelmagan/cheatsheet)


### PR DESCRIPTION
Added language badges to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, and Russian 20 languages.
System will auto-update translation for README and Wiki when this repository updated, and support multiple languages google/bing SEO search, and it's open source project, we can change web or local file mode.

The updated links can be previewed in my forked repository: https://github.com/openaitx-system/cheatsheet/tree/Auto_translate_README_and_Wiki

Demo links : 
- [Español](https://openaitx.github.io/view.html?user=michaelmagan&project=cheatsheet&lang=es)
- [简体中文](https://openaitx.github.io/view.html?user=michaelmagan&project=cheatsheet&lang=zh-CN)
- [日本語](https://openaitx.github.io/view.html?user=michaelmagan&project=cheatsheet&lang=ja)
- [한국어](https://openaitx.github.io/view.html?user=michaelmagan&project=cheatsheet&lang=ko)
- [Français](https://openaitx.github.io/view.html?user=michaelmagan&project=cheatsheet&lang=fr)
..


<img width="1178" height="537" alt="Image" src="https://github.com/user-attachments/assets/7cd54a88-59c1-455f-9c7d-2db7f05b2962  " />

If this doesn't align with your expectations, feel free to close this PR. Thanks for your time! 🙌

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves README accessibility by surfacing translated docs.
> 
> - Adds a right-aligned collapsible "Language" section in `README.md` with links to ~20 localized versions (EN, ZH, JA, KO, FR, DE, ES, IT, RU, PT, NL, PL, AR, FA, TR, VI, ID, etc.)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f881295a05289b21ee42e6d3a7dfc071f4ffc5b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->